### PR TITLE
feat: enable compression and cache control

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -4,13 +4,15 @@ const { Server } = require("socket.io");
 const Redis = require("ioredis");
 
 const path = require("path");
+const compression = require("compression"); // CHANGED
 
 const app = express();
+app.use(compression()); // CHANGED
 // LogRocket CDN 허용
 
 app.use('/server/public', express.static(path.join(__dirname, 'icon'))); // ✅ CHANGED
 // 기본 static 경로 제한
-app.use(express.static(path.join(__dirname, 'public'))); // CHANGED
+app.use(express.static(path.join(__dirname, 'public'), { maxAge: '1d', etag: false })); // CHANGED
 const server = http.createServer(app);
 const io = new Server(server, {
   cors: { origin: "*" },


### PR DESCRIPTION
## Summary
- add compression middleware to express server
- cache static assets for one day and disable etag

## Testing
- `npm test` (fails: Error: no test specified)
- `npm install compression ioredis` (fails: 403 Forbidden)
- `node server/server.js` (fails: Cannot find module 'ioredis')

------
https://chatgpt.com/codex/tasks/task_e_688f0f310ef483329f36774a31847fa5