### PR TITLE
feat: enable compression and cache control

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
+    "compression": "^1.7.4",
     "express": "^5.1.0",
+    "ioredis": "^5.3.2",
     "socket.io": "^4.8.1",
     "socket.io-client": "^4.8.1",
     "uuid": "^11.1.0"

--- a/server/server.js
+++ b/server/server.js
@@ -4,13 +4,15 @@ const { Server } = require("socket.io");
 const Redis = require("ioredis");
 
 const path = require("path");
+const compression = require("compression"); // CHANGED
 
 const app = express();
+app.use(compression()); // CHANGED
 // LogRocket CDN 허용
 
-app.use('/server/public', express.static(path.join(__dirname, 'icon'))); // ✅ CHANGED
+app.use('/server/public', express.static(path.join(__dirname, 'icon'), { maxAge: '1d', etag: false })); // CHANGED
 // 기본 static 경로 제한
-app.use(express.static(path.join(__dirname, 'public'))); // CHANGED
+app.use(express.static(path.join(__dirname, 'public'), { maxAge: '1d', etag: false })); // CHANGED
 const server = http.createServer(app);
 const io = new Server(server, {
   cors: { origin: "*" },
@@ -46,7 +48,7 @@ io.on("connection", (socket) => {
   });
 });
 
-// 5초마다 모니터링 로그 출력
+// 10초마다 모니터링 로그 출력 // CHANGED
 setInterval(() => {
   console.log(
     `[MONITOR] 현재 접속자: ${io.engine.clientsCount}, 누적 접속자: ${totalConnections}, 누적 전송량: ${totalBytes} bytes`


### PR DESCRIPTION
## Summary
- add compression middleware to express server
- cache static assets (icons and public) for one day and disable etag
- include compression and ioredis dependencies

## Testing
- `npm install compression@1.7.4 ioredis@5.3.2` (fails: 403 Forbidden)
- `npm test` (fails: Error: no test specified)
- `node server/server.js` (fails: Cannot find module 'ioredis')

------
https://chatgpt.com/codex/tasks/task_e_688f0f310ef483329f36774a31847fa5