### PR TITLE
fix: remove stray merge strings from server

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -11,9 +11,8 @@ app.use(compression()); // CHANGED
 // LogRocket CDN 허용
 
 app.use('/server/public', express.static(path.join(__dirname, 'icon'), { maxAge: '1d', etag: false })); // CHANGED
-62a0e4-codex/add-compression-and-caching-options
+// CHANGED: removed stray merge artifact lines
 app.use('/AD', express.static(path.join(__dirname, 'AD'), { maxAge: '1d', etag: false })); // CHANGED
-main
 // 기본 static 경로 제한
 app.use(express.static(path.join(__dirname, 'public'), { maxAge: '1d', etag: false })); // CHANGED
 const server = http.createServer(app);


### PR DESCRIPTION
## Summary
- remove merge artifacts in server static middleware

## Testing
- `npm test` (fails: Error: no test specified)
- `node --check server/server.js`
- `pm2 restart gistniga` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f789d2adc83329872aa597c4e555b