### PR TITLE
fix: ensure sockets leave rooms on exit

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -66,11 +66,15 @@ matchmaker.on("match", (socketId1, socketId2) => {
 async function handleLeave(socket) {
   const roomId = socket.roomId;
   if (roomId) {
+    socket.leave(roomId); // CHANGED: ensure leaving socket.io room
+    socket.roomId = null; // CHANGED
     const users = await queue.redis.hget(ROOMS_KEY, roomId);
     if (users) {
       const otherId = JSON.parse(users).find((id) => id !== socket.id);
       const otherSocket = io.sockets.sockets.get(otherId);
       if (otherSocket) {
+        otherSocket.leave(roomId); // CHANGED
+        otherSocket.roomId = null; // CHANGED
         otherSocket.emit("partner left");
       }
       await removeRoom(roomId);


### PR DESCRIPTION
## Summary
- properly remove both participants from socket.io rooms when a chat ends

## Testing
- `npm test` *(fails: no test specified)*
- `node server/server.js` *(fails: connect ECONNREFUSED 127.0.0.1:6379)*

------
https://chatgpt.com/codex/tasks/task_e_68901e62cd6c8332aa62ac972bf9cce9