### PR TITLE
fix socket initialization and serve static assets

### DIFF
--- a/server/public/chat.html
+++ b/server/public/chat.html
@@ -99,6 +99,11 @@
     </div>
   </div>
   <script src="/socket.io/socket.io.js"></script>
+  <script>
+    if (typeof io === 'undefined') {
+      document.write('<script src="https://cdn.socket.io/4.8.1/socket.io.min.js"><\\/script>'); // CHANGED
+    }
+  </script> <!-- CHANGED: fallback for socket.io -->
   <script src="common.js"></script>
   <script src="app.js"></script>
 

--- a/server/public/common.js
+++ b/server/public/common.js
@@ -1,8 +1,16 @@
-
-const socket = io();
+let socket; // CHANGED: allow graceful load
+try {
+  socket = io(); // CHANGED: initialize socket if available
+} catch (e) {
+  console.error('Socket.io client failed to load', e); // CHANGED
+}
 
 function setupGistChat(config) {
   const { mainButton, messageInput, sendButton, messages, adPopupOverlay, adCloseBtn, adStorageKey, adPopupInterval } = config;
+  if (!socket) { // CHANGED: prevent usage without socket
+    console.error('Socket not initialized'); // CHANGED
+    return; // CHANGED
+  }
 
   let chatting = false, myRoomId = null;
   let typingTimeout = null;
@@ -156,12 +164,12 @@ function setupGistChat(config) {
 
 // === Global Listeners (outside the main function) ===
 window.onerror = function (message, source, lineno, colno, error) {
-  socket.emit("client error", { message, source, lineno, colno });
+  if (socket) socket.emit("client error", { message, source, lineno, colno }); // CHANGED
 };
 window.addEventListener("unhandledrejection", (event) => {
-  socket.emit("client error", { message: event.reason?.message || "Promise rejection" });
+  if (socket) socket.emit("client error", { message: event.reason?.message || "Promise rejection" }); // CHANGED
 });
 
 setInterval(() => {
-  socket.emit("client ping", { ts: Date.now(), url: location.href });
+  if (socket) socket.emit("client ping", { ts: Date.now(), url: location.href }); // CHANGED
 }, 5000);

--- a/server/public/mobile.html
+++ b/server/public/mobile.html
@@ -104,6 +104,11 @@
     </div>
   </div>
   <script src="/socket.io/socket.io.js"></script>
+  <script>
+    if (typeof io === 'undefined') {
+      document.write('<script src="https://cdn.socket.io/4.8.1/socket.io.min.js"><\\/script>'); // CHANGED
+    }
+  </script> <!-- CHANGED: fallback for socket.io -->
   <script src="common.js"></script>
   <script src="mobile.js"></script>
 

--- a/server/server.js
+++ b/server/server.js
@@ -6,7 +6,7 @@ const Queue = require("./queue");
 const Matchmaker = require("./matchmaker");
 
 const app = express();
-app.use('/server/public', express.static(path.join(__dirname, 'icon')));
+app.use('/AD', express.static(path.join(__dirname, 'AD'))); // CHANGED: serve ad images
 app.use(express.static(path.join(__dirname, 'public')));
 
 const server = http.createServer(app);


### PR DESCRIPTION
## Summary
- serve ad images correctly from `/AD`
- guard socket.io usage and add CDN fallback on chat pages
- handle missing socket client safely

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68902abd646083329d4dc7281743bfa1